### PR TITLE
Fix compatibility with recent versions of python cryptography

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Deprecated
+
+Cozy coclyco has been deprecated in favor of detailed installation instructions to let you manager your reverse proxy if you prefer anything other thnt nginx.
+
+See [the selfhosting documentation](https://docs.cozy.io/en/tutorials/selfhosting/)
+
 # Coclyco
 
 ## Goal

--- a/cozy/coclyco/backup.py
+++ b/cozy/coclyco/backup.py
@@ -36,11 +36,11 @@ class Backup:
         local = path + ".local"
         if os.path.isfile(local):
             with open(local, "r") as file:
-                tmp = yaml.load(file)
+                tmp = yaml.safe_load(file)
             config = merge(tmp, config)
         if os.path.isfile(path):
             with open(path, "r") as file:
-                tmp = yaml.load(file)
+                tmp = yaml.safe_load(file)
             config = merge(tmp, config)
         return config
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyOpenSSL
-cryptography
+cryptography<42.0.0
 pyasn1
 pyasn1-modules
 josepy
@@ -8,3 +8,4 @@ setuptools
 couchdb >=1.1
 pyyaml
 requests
+packaging


### PR DESCRIPTION
Fix compatibility with recent versions of python cryptography (make it compatible with python cryptography 39.0.0 to 41.x.x).

Starting from upcoming python-cryptography 42.0.0 some backend functions we use are removed by https://github.com/pyca/cryptography/pull/9673 so we limit python cryptography to <42.0.0)

This PR also fixes yaml config file loading